### PR TITLE
Run CI on pull request events not pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This is to allow for PRs from forks to be able to pass CI