### PR TITLE
chore: remove compositor state

### DIFF
--- a/balccon/src/index.ts
+++ b/balccon/src/index.ts
@@ -12,7 +12,6 @@ import {
   PixelInfo,
   tee,
 } from '@synesthesia-project/compositor';
-import { SynesthesiaPlayState } from '@synesthesia-project/compositor/lib/modules';
 import FillModule from '@synesthesia-project/compositor/lib/modules/fill';
 import AddModule from '@synesthesia-project/compositor/lib/modules/add';
 import ScanModule from '@synesthesia-project/compositor/lib/modules/scan';
@@ -37,11 +36,11 @@ export class Display {
 
   private buffer: Buffer;
   private pulse?: {
-    module: ModulateModule<unknown>;
+    module: ModulateModule;
     alpha: number;
     up: boolean;
   };
-  private compositor: Compositor<number, { synesthesia: SynesthesiaPlayState }>;
+  private compositor: Compositor<number>;
   private stream: fs.WriteStream;
 
   public constructor() {
@@ -56,40 +55,34 @@ export class Display {
       };
     }
 
-    this.compositor = new Compositor<
-      number,
-      { synesthesia: SynesthesiaPlayState }
-    >(
-      {
-        root: new SynesthesiaModulateModule(
-          new AddModule([
-            tee(
-              (module) => (this.pulse = { module, alpha: 1, up: true }),
-              new ModulateModule(new FillModule(new RGBAColor(96, 0, 160, 1)))
-            ),
-            new ScanModule(new RGBAColor(160, 0, 104, 1), {
-              delay: 0,
-              speed: -0.1,
-            }),
-            new ScanModule(new RGBAColor(160, 0, 104, 1), { speed: 0.5 }),
-            new ScanModule(new RGBAColor(160, 0, 104, 1), {
-              delay: 0,
-              speed: 0.2,
-            }),
-            new ScanModule(new RGBAColor(247, 69, 185, 1), {
-              delay: 0,
-              speed: -0.3,
-            }),
-            new ScanModule(new RGBAColor(247, 69, 185, 1), {
-              delay: 1,
-              speed: 0.3,
-            }),
-          ])
-        ),
-        pixels,
-      },
-      { synesthesia: this.state }
-    );
+    this.compositor = new Compositor<number>({
+      root: new SynesthesiaModulateModule(
+        new AddModule([
+          tee(
+            (module) => (this.pulse = { module, alpha: 1, up: true }),
+            new ModulateModule(new FillModule(new RGBAColor(96, 0, 160, 1)))
+          ),
+          new ScanModule(new RGBAColor(160, 0, 104, 1), {
+            delay: 0,
+            speed: -0.1,
+          }),
+          new ScanModule(new RGBAColor(160, 0, 104, 1), { speed: 0.5 }),
+          new ScanModule(new RGBAColor(160, 0, 104, 1), {
+            delay: 0,
+            speed: 0.2,
+          }),
+          new ScanModule(new RGBAColor(247, 69, 185, 1), {
+            delay: 0,
+            speed: -0.3,
+          }),
+          new ScanModule(new RGBAColor(247, 69, 185, 1), {
+            delay: 1,
+            speed: 0.3,
+          }),
+        ])
+      ),
+      pixels,
+    });
 
     this.stream = fs.createWriteStream('/tmp/leds');
 
@@ -138,7 +131,8 @@ export class Display {
               );
               this.state = { playState, files: nextFiles };
 
-              this.compositor.updateState({ synesthesia: this.state });
+              // this.compositor.updateState({ synesthesia: this.state });
+              // TODO: update the synesthezia module directly
             }
           },
           {

--- a/compositor/src/lib/compositor.ts
+++ b/compositor/src/lib/compositor.ts
@@ -1,8 +1,8 @@
 import { PixelMap, CompositorModule, PixelInfo } from './modules';
 import { RGBAColor } from './color';
 
-export interface Config<PixelData, State> {
-  root: CompositorModule<State>;
+export interface Config<PixelData> {
+  root: CompositorModule;
   pixels: PixelInfo<PixelData>[];
 }
 
@@ -11,15 +11,12 @@ type RenderResult<PixelData> = {
   output: RGBAColor;
 }[];
 
-export class Compositor<PixelData, State> {
-  private readonly config: Config<PixelData, State>;
+export class Compositor<PixelData> {
+  private readonly config: Config<PixelData>;
   private readonly map: PixelMap;
 
-  private state: State;
-
-  public constructor(config: Config<PixelData, State>, initialState: State) {
+  public constructor(config: Config<PixelData>) {
     this.config = config;
-    this.state = initialState;
 
     // Calculate Map
     const xs = config.pixels.map((p) => p.x);
@@ -33,21 +30,12 @@ export class Compositor<PixelData, State> {
   }
 
   public renderFrame(): RenderResult<PixelData> {
-    const result = this.config.root.render(
-      this.map,
-      this.config.pixels,
-      this.state
-    );
+    const result = this.config.root.render(this.map, this.config.pixels);
     if (result.length !== this.config.pixels.length)
       throw new Error('Unexpected number of pixels returned');
     return this.config.pixels.map((pixel, i) => ({
       pixel,
       output: result[i],
     }));
-  }
-
-  public updateState(state: State) {
-    // TODO: transition
-    this.state = state;
   }
 }

--- a/compositor/src/lib/modules/add.ts
+++ b/compositor/src/lib/modules/add.ts
@@ -26,24 +26,20 @@ export function alphaCombine(bottom: RGBAColor, top: RGBAColor) {
 /**
  * Combine the output of multiple modules together in an "additive" manner
  */
-export default class AddModule<State> implements CompositorModule<State> {
-  private layers: CompositorModule<State>[];
+export default class AddModule implements CompositorModule {
+  private layers: CompositorModule[];
 
-  public constructor(layers: CompositorModule<State>[]) {
+  public constructor(layers: CompositorModule[]) {
     if (layers.length === 0) throw new Error('must supply at least one layer');
     this.layers = [...layers];
   }
 
-  public render(
-    map: PixelMap,
-    pixels: PixelInfo<unknown>[],
-    state: State
-  ): RGBAColor[] {
-    const result = this.layers[0].render(map, pixels, state);
+  public render(map: PixelMap, pixels: PixelInfo<unknown>[]): RGBAColor[] {
+    const result = this.layers[0].render(map, pixels);
     if (result.length !== pixels.length)
       throw new Error('Unexpected number of pixels returned');
     for (let l = 1; l < this.layers.length; l++) {
-      const layerResult = this.layers[l].render(map, pixels, state);
+      const layerResult = this.layers[l].render(map, pixels);
       if (layerResult.length !== pixels.length)
         throw new Error('Unexpected number of pixels returned');
       for (let i = 0; i < pixels.length; i++)
@@ -52,7 +48,7 @@ export default class AddModule<State> implements CompositorModule<State> {
     return result;
   }
 
-  public setLayers = (layers: CompositorModule<State>[]) => {
+  public setLayers = (layers: CompositorModule[]) => {
     if (layers.length === 0) throw new Error('must supply at least one layer');
     this.layers = [...layers];
   };

--- a/compositor/src/lib/modules/chase.ts
+++ b/compositor/src/lib/modules/chase.ts
@@ -2,10 +2,10 @@ import { CompositorModule, RenderMethod } from '.';
 import { RGBAColor } from '../color';
 import { restrictNumber } from '../util';
 
-export class ChaseModule<State> implements CompositorModule<State> {
+export class ChaseModule implements CompositorModule {
   private advanceAmountPerSecond: number;
 
-  private readonly sequence: Array<CompositorModule<State>>;
+  private readonly sequence: Array<CompositorModule>;
 
   /**
    * Array of values from 0-colors.length that
@@ -20,7 +20,7 @@ export class ChaseModule<State> implements CompositorModule<State> {
   private lastFrame = Date.now();
 
   public constructor(
-    sequence: Array<CompositorModule<State>>,
+    sequence: Array<CompositorModule>,
     options?: {
       advanceAmountPerSecond?: number;
     }
@@ -29,7 +29,7 @@ export class ChaseModule<State> implements CompositorModule<State> {
     this.advanceAmountPerSecond = options?.advanceAmountPerSecond || 0.3;
   }
 
-  render: RenderMethod<State> = (map, pixels, state) => {
+  render: RenderMethod = (map, pixels) => {
     // How many seconds since last frame
     const now = Date.now();
     const diff = (now - this.lastFrame) / 1000;
@@ -57,8 +57,8 @@ export class ChaseModule<State> implements CompositorModule<State> {
       );
       const module2 = module1 + 1 >= this.sequence.length ? 0 : module1 + 1;
       const transition = restrictNumber(pos - module1, 0, 1);
-      const color1 = this.sequence[module1].render(map, [info], state)[0];
-      const color2 = this.sequence[module2].render(map, [info], state)[0];
+      const color1 = this.sequence[module1].render(map, [info])[0];
+      const color2 = this.sequence[module2].render(map, [info])[0];
       return color1.transition(color2, transition);
     });
     return result;

--- a/compositor/src/lib/modules/fill.ts
+++ b/compositor/src/lib/modules/fill.ts
@@ -4,20 +4,15 @@ import { PixelMap, PixelInfo, CompositorModule } from './';
 /**
  * Module that fills all pixels with a given color
  */
-export default class FillModule<State> implements CompositorModule<State> {
-  private readonly color: ((state: State) => RGBAColor) | RGBAColor;
+export default class FillModule implements CompositorModule {
+  private readonly color: (() => RGBAColor) | RGBAColor;
 
-  public constructor(color: ((state: State) => RGBAColor) | RGBAColor) {
+  public constructor(color: (() => RGBAColor) | RGBAColor) {
     this.color = color;
   }
 
-  public render(
-    _map: PixelMap,
-    pixels: PixelInfo<unknown>[],
-    state: State
-  ): RGBAColor[] {
-    const color =
-      typeof this.color === 'function' ? this.color(state) : this.color;
+  public render(_map: PixelMap, pixels: PixelInfo<unknown>[]): RGBAColor[] {
+    const color = typeof this.color === 'function' ? this.color() : this.color;
     const result: RGBAColor[] = [];
     for (const _ of pixels) result.push(color);
     return result;

--- a/compositor/src/lib/modules/index.ts
+++ b/compositor/src/lib/modules/index.ts
@@ -18,14 +18,13 @@ export interface PixelInfo<Data> {
   data: Data;
 }
 
-export type RenderMethod<State> = (
+export type RenderMethod = (
   map: PixelMap,
-  pixels: PixelInfo<unknown>[],
-  state: State
+  pixels: PixelInfo<unknown>[]
 ) => RGBAColor[];
 
-export interface CompositorModule<State> {
-  render: RenderMethod<State>;
+export interface CompositorModule {
+  render: RenderMethod;
 }
 
 export interface SynesthesiaPlayState {

--- a/compositor/src/lib/modules/scan.ts
+++ b/compositor/src/lib/modules/scan.ts
@@ -22,11 +22,8 @@ interface Origin {
   xRatio: number;
 }
 
-/**
- * Module that fills all pixels with a given color
- */
-export default class ScanModule<State> implements CompositorModule<State> {
-  private readonly color: ((state: State) => RGBAColor) | RGBAColor;
+export default class ScanModule implements CompositorModule {
+  private readonly color: (() => RGBAColor) | RGBAColor;
 
   private readonly beamWidth: number;
   private readonly delay: number;
@@ -54,7 +51,7 @@ export default class ScanModule<State> implements CompositorModule<State> {
   private origin: Origin;
 
   public constructor(
-    color: ((state: State) => RGBAColor) | RGBAColor,
+    color: (() => RGBAColor) | RGBAColor,
     options: Partial<ScanOptions> = {}
   ) {
     this.color = color;
@@ -75,11 +72,7 @@ export default class ScanModule<State> implements CompositorModule<State> {
     };
   }
 
-  public render(
-    map: PixelMap,
-    pixels: PixelInfo<unknown>[],
-    state: State
-  ): RGBAColor[] {
+  public render(map: PixelMap, pixels: PixelInfo<unknown>[]): RGBAColor[] {
     const now = new Date().getTime();
     const diff = now - this.origin.time;
     /** 0 = start of map, 1 = end of map */
@@ -93,8 +86,7 @@ export default class ScanModule<State> implements CompositorModule<State> {
       this.origin.xRatio = xRatio = xRatio + this.xRatioShift;
     }
     const mapWidth = map.xMax - map.xMin;
-    const color =
-      typeof this.color === 'function' ? this.color(state) : this.color;
+    const color = typeof this.color === 'function' ? this.color() : this.color;
     return pixels.map((pixel) => {
       const pixelXRatio = (pixel.x - map.xMin) / mapWidth;
       const distance = Math.abs(pixelXRatio - xRatio);

--- a/compositor/src/lib/modules/splitter.ts
+++ b/compositor/src/lib/modules/splitter.ts
@@ -1,10 +1,7 @@
 import { CompositorModule, PixelInfo, RenderMethod } from '.';
 import { RGBAColor } from '../color';
 
-interface SplitterOpts<
-  State,
-  Map extends { [key: string]: CompositorModule<State> }
-> {
+interface SplitterOpts<Map extends { [key: string]: CompositorModule }> {
   modules: Map;
   /**
    * Return the key of the module you're selecting
@@ -16,25 +13,23 @@ interface SplitterOpts<
  * Provide multiple modules,
  * and choose which pixels use which modules
  */
-export class SplitterModule<
-  State,
-  Map extends { [key: string]: CompositorModule<State> }
-> implements CompositorModule<State>
+export class SplitterModule<Map extends { [key: string]: CompositorModule }>
+  implements CompositorModule
 {
-  private readonly opts: SplitterOpts<State, Map>;
+  private readonly opts: SplitterOpts<Map>;
 
-  public constructor(opts: SplitterOpts<State, Map>) {
+  public constructor(opts: SplitterOpts<Map>) {
     this.opts = opts;
   }
 
-  render: RenderMethod<State> = (map, pixels, state) => {
+  render: RenderMethod = (map, pixels) => {
     const frames: { [K in keyof Map]: RGBAColor[] } = {} as any;
 
     for (const [name, module] of Object.entries(this.opts.modules) as [
       keyof Map,
-      CompositorModule<State>
+      CompositorModule
     ][]) {
-      frames[name] = module.render(map, pixels, state);
+      frames[name] = module.render(map, pixels);
     }
 
     return pixels.map((p, i) => frames[this.opts.selectModuleByPixel(p, i)][i]);

--- a/compositor/src/lib/modules/transition.ts
+++ b/compositor/src/lib/modules/transition.ts
@@ -1,6 +1,6 @@
 import { CompositorModule, RenderMethod } from '.';
 
-export class TransitionModule<State> implements CompositorModule<State> {
+export class TransitionModule implements CompositorModule {
   private readonly modules: {
     /**
      * Value from 0-1 that represents how far this module has transitioned in.
@@ -13,7 +13,7 @@ export class TransitionModule<State> implements CompositorModule<State> {
      * What ratio to transition in 1 second
      */
     transitionSpeed: number;
-    module: CompositorModule<State>;
+    module: CompositorModule;
   }[];
 
   /**
@@ -22,7 +22,7 @@ export class TransitionModule<State> implements CompositorModule<State> {
    */
   private lastFrame = Date.now();
 
-  public constructor(init: CompositorModule<State>) {
+  public constructor(init: CompositorModule) {
     this.modules = [
       {
         transitionAmount: 1,
@@ -32,16 +32,16 @@ export class TransitionModule<State> implements CompositorModule<State> {
     ];
   }
 
-  render: RenderMethod<State> = (map, pixels, state) => {
+  render: RenderMethod = (map, pixels) => {
     // How many seconds since last frame
     const now = Date.now();
     const diff = (now - this.lastFrame) / 1000;
     this.lastFrame = now;
     // Calculate the current frame
-    const result = this.modules[0].module.render(map, pixels, state);
+    const result = this.modules[0].module.render(map, pixels);
     for (let i = 1; i < this.modules.length; i++) {
       const next = this.modules[i];
-      const nextFrame = next.module.render(map, pixels, state);
+      const nextFrame = next.module.render(map, pixels);
       if (result.length !== nextFrame.length) {
         console.error('mismatched frame lengths');
       } else {
@@ -66,7 +66,7 @@ export class TransitionModule<State> implements CompositorModule<State> {
   };
 
   transition = (
-    newPattern: CompositorModule<State>,
+    newPattern: CompositorModule,
     transitionLengthSeconds: number
   ) => {
     this.modules.push({

--- a/live/app/src/plugins/chase-input.ts
+++ b/live/app/src/plugins/chase-input.ts
@@ -34,7 +34,7 @@ const createAddInput = (context: InputContext<Config>): Input<Config> => {
 
   const group = new ld.Group({ direction: 'vertical', noBorder: true });
   const module = new TransitionModule(new FillModule(RGBA_TRANSPARENT));
-  let chaseModule: ChaseModule<unknown> | null = null;
+  let chaseModule: ChaseModule | null = null;
 
   const layers: Array<Input<OptionalKindAndConfig>> = [];
 

--- a/live/app/src/plugins/fill-input.ts
+++ b/live/app/src/plugins/fill-input.ts
@@ -31,7 +31,7 @@ const createFillInput = (context: InputContext<Config>): Input<Config> => {
   };
 
   const group = new ld.Group({ noBorder: true });
-  const module = new FillModule<unknown>(() => state.color);
+  const module = new FillModule(() => state.color);
 
   const rect = group.addChild(new ld.Rect());
 

--- a/live/app/src/stage.ts
+++ b/live/app/src/stage.ts
@@ -48,7 +48,7 @@ export const Stage = async (plugins: Plugin[], configPath: string) => {
   const inputManager = createInputManager();
 
   const compositor: {
-    root: TransitionModule<unknown>;
+    root: TransitionModule;
     current: null | string;
     cues: Map<string, InputSocket>;
   } = {
@@ -151,7 +151,7 @@ export const Stage = async (plugins: Plugin[], configPath: string) => {
       }
     };
     const render: OutputContext<ConfigT>['render'] = (map, pixels) =>
-      compositor.root.render(map, pixels, null);
+      compositor.root.render(map, pixels);
     const setChannels: OutputContext<ConfigT>['setChannels'] = (channels) => {
       activeOutput.channels = channels;
       sendChannelsToSequences();

--- a/live/core/src/plugins/index.ts
+++ b/live/core/src/plugins/index.ts
@@ -88,7 +88,7 @@ export interface Module<ConfigT> {
 export type Output<ConfigT> = Module<ConfigT>;
 
 export interface Input<ConfigT> extends Module<ConfigT> {
-  getModlue(): CompositorModule<unknown>;
+  getModlue(): CompositorModule;
 }
 
 export interface ModuleKind<ConfigT> {

--- a/synesthesia-razer/src/index.ts
+++ b/synesthesia-razer/src/index.ts
@@ -50,7 +50,7 @@ export class Display {
       buffer: { index: number; start: number; colors: openrazer.RGB[] }[];
     };
     mousemat: MouseMat | null;
-    compositor: Compositor<PixelData, { synesthesia: SynesthesiaPlayState }>;
+    compositor: Compositor<PixelData>;
   } | null = null;
   private x = 0;
 
@@ -101,10 +101,7 @@ export class Display {
               );
               this.state = { playState, files: nextFiles };
               // Update the state of any compositors
-              if (this.devices)
-                this.devices.compositor.updateState({
-                  synesthesia: this.state,
-                });
+              // TODO: update the state of the synesthezia modulator
             }
           },
           {
@@ -215,37 +212,31 @@ export class Display {
         mousemat = { dev, map, buffer };
       }
 
-      const compositor = new Compositor<
-        PixelData,
-        { synesthesia: SynesthesiaPlayState }
-      >(
-        {
-          root: new SynesthesiaModulateModule(
-            new AddModule([
-              new FillModule(new RGBAColor(96, 0, 160, 1)),
-              new ScanModule(new RGBAColor(160, 0, 104, 1), {
-                delay: 0,
-                speed: -0.1,
-              }),
-              new ScanModule(new RGBAColor(160, 0, 104, 1), { speed: 0.5 }),
-              new ScanModule(new RGBAColor(160, 0, 104, 1), {
-                delay: 0,
-                speed: 0.2,
-              }),
-              new ScanModule(new RGBAColor(247, 69, 185, 1), {
-                delay: 0,
-                speed: -0.3,
-              }),
-              new ScanModule(new RGBAColor(247, 69, 185, 1), {
-                delay: 1,
-                speed: 0.3,
-              }),
-            ])
-          ),
-          pixels,
-        },
-        { synesthesia: this.state }
-      );
+      const compositor = new Compositor<PixelData>({
+        root: new SynesthesiaModulateModule(
+          new AddModule([
+            new FillModule(new RGBAColor(96, 0, 160, 1)),
+            new ScanModule(new RGBAColor(160, 0, 104, 1), {
+              delay: 0,
+              speed: -0.1,
+            }),
+            new ScanModule(new RGBAColor(160, 0, 104, 1), { speed: 0.5 }),
+            new ScanModule(new RGBAColor(160, 0, 104, 1), {
+              delay: 0,
+              speed: 0.2,
+            }),
+            new ScanModule(new RGBAColor(247, 69, 185, 1), {
+              delay: 0,
+              speed: -0.3,
+            }),
+            new ScanModule(new RGBAColor(247, 69, 185, 1), {
+              delay: 1,
+              speed: 0.3,
+            }),
+          ])
+        ),
+        pixels,
+      });
       this.devices = {
         keyboard: { dev: keyboard, map, buffer },
         mousemat,


### PR DESCRIPTION
it turns out it's a lot easier to just directly interact with module instances, so do that instead, and lose the generics which don't really add anything.

fixes #158